### PR TITLE
Update index.yml - remove ms.service: cloud-services

### DIFF
--- a/microsoft-community-training/index.yml
+++ b/microsoft-community-training/index.yml
@@ -6,7 +6,6 @@ summary: Microsoft Community Training is a cloud-based solution that enables del
 metadata:
   title: Microsoft Community Training
   description: This site is for administrators of Microsoft Community Training platform to understand the platform and its usage.
-  ms.service: cloud-services
   ms.topic: landing-page
   author: nikotha
   ms.author: nikotha


### PR DESCRIPTION
The metadata tag ms.service is supposed to denote the service slug for the Azure service it covers. The slug `cloud-services` is used for the service "Azure Cloud Services". I don't think this content is related to Cloud Services, so I am removing the tag. Having this tag in this content is skewing our doc metrics.